### PR TITLE
GridFieldOrderableRows: Prefix sort field with table name when sorting

### DIFF
--- a/code/GridFieldOrderableRows.php
+++ b/code/GridFieldOrderableRows.php
@@ -26,6 +26,14 @@ class GridFieldOrderableRows extends RequestHandler implements
 	protected $sortField;
 
 	/**
+	 * Extra sort fields to apply before the sort field.
+	 *
+	 * @see setExtraSortFields()
+	 * @var string|array
+	 */
+	protected $extraSortFields = null;
+
+	/**
 	 * @param string $sortField
 	 */
 	public function __construct($sortField = 'Sort') {
@@ -47,6 +55,24 @@ class GridFieldOrderableRows extends RequestHandler implements
 	 */
 	public function setSortField($field) {
 		$this->sortField = $field;
+		return $this;
+	}
+
+	/**
+	 * @return string|array
+	 */
+	public function getExtraSortFields() {
+		return $this->extraSortFields;
+	}
+
+	/**
+	 * Sets extra sort fields to apply before the sort field.
+	 *
+	 * @param string|array $fields
+	 * @return GridFieldOrderableRows $this
+	 */
+	public function setExtraSortFields($fields) {
+		$this->extraSortFields = $fields;
 		return $this;
 	}
 
@@ -128,7 +154,18 @@ class GridFieldOrderableRows extends RequestHandler implements
 		$state->GridFieldOrderableRows->enabled = !$sorted;
 
 		if(!$sorted) {
-			return $list->sort($this->getSortTable($list).'.'.$this->getSortField());
+			$sortterm = '';
+			if ($this->extraSortFields) {
+				if (is_array($this->extraSortFields)) {
+					foreach($this->extraSortFields as $col => $dir) {
+						$sortterm .= "$col $dir, ";
+					}
+				} else {
+					$sortterm = $this->extraSortFields.', ';
+				}
+			}
+			$sortterm .= $this->getSortTable($list).'.'.$this->getSortField();
+			return $list->sort($sortterm);
 		} else {
 			return $list;
 		}
@@ -150,7 +187,18 @@ class GridFieldOrderableRows extends RequestHandler implements
 			$this->httpError(400);
 		}
 
-		$items = $list->byIDs($ids)->sort($this->getSortTable($list).'.'.$field);
+		$sortterm = '';
+		if ($this->extraSortFields) {
+			if (is_array($this->extraSortFields)) {
+				foreach($this->extraSortFields as $col => $dir) {
+					$sortterm .= "$col $dir, ";
+				}
+			} else {
+				$sortterm = $this->extraSortFields.', ';
+			}
+		}
+		$sortterm .= $this->getSortTable($list).'.'.$field;
+		$items = $list->byIDs($ids)->sort($sortterm);
 
 		// Ensure that each provided ID corresponded to an actual object.
 		if(count($items) != count($ids)) {

--- a/code/GridFieldOrderableRows.php
+++ b/code/GridFieldOrderableRows.php
@@ -128,7 +128,7 @@ class GridFieldOrderableRows extends RequestHandler implements
 		$state->GridFieldOrderableRows->enabled = !$sorted;
 
 		if(!$sorted) {
-			return $list->sort($this->getSortField());
+			return $list->sort($this->getSortTable($list).'.'.$this->getSortField());
 		} else {
 			return $list;
 		}
@@ -150,7 +150,7 @@ class GridFieldOrderableRows extends RequestHandler implements
 			$this->httpError(400);
 		}
 
-		$items = $list->byIDs($ids)->sort($field);
+		$items = $list->byIDs($ids)->sort($this->getSortTable($list).'.'.$field);
 
 		// Ensure that each provided ID corresponded to an actual object.
 		if(count($items) != count($ids)) {

--- a/code/GridFieldOrderableRows.php
+++ b/code/GridFieldOrderableRows.php
@@ -34,6 +34,14 @@ class GridFieldOrderableRows extends RequestHandler implements
 	protected $extraSortFields = null;
 
 	/**
+	 * The number of the column containing the reorder handles
+	 *
+	 * @see setReorderColumnNumber()
+	 * @var integer
+	 */
+	protected $reorderColumnNumber = 0;
+
+	/**
 	 * @param string $sortField
 	 */
 	public function __construct($sortField = 'Sort') {
@@ -73,6 +81,24 @@ class GridFieldOrderableRows extends RequestHandler implements
 	 */
 	public function setExtraSortFields($fields) {
 		$this->extraSortFields = $fields;
+		return $this;
+	}
+
+	/**
+	 * @return integer
+	 */
+	public function getReorderColumnNumber() {
+		return $this->reorderColumnNumber;
+	}
+
+	/**
+	 * Sets the number of the column containing the reorder handles.
+	 *
+	 * @param integer $colno
+	 * @return GridFieldOrderableRows $this
+	 */
+	public function setReorderColumnNumber($colno) {
+		$this->reorderColumnNumber = $colno;
 		return $this;
 	}
 
@@ -125,7 +151,7 @@ class GridFieldOrderableRows extends RequestHandler implements
 
 	public function augmentColumns($grid, &$cols) {
 		if(!in_array('Reorder', $cols) && $grid->getState()->GridFieldOrderableRows->enabled) {
-			array_unshift($cols, 'Reorder');
+			array_splice($cols, $this->reorderColumnNumber, 0, 'Reorder');
 		}
 	}
 


### PR DESCRIPTION
Prevents ambiguities when the GridField's underlying DataList uses a query
that joins multiple tables having a sort field.