### PR TITLE
FIX Filter by ID to be more compatible with `ArrayList`

### DIFF
--- a/code/GridFieldOrderableRows.php
+++ b/code/GridFieldOrderableRows.php
@@ -224,7 +224,7 @@ class GridFieldOrderableRows extends RequestHandler implements
 			}
 		}
 		$sortterm .= $field;
-		$items = $list->byIDs($ids)->sort($sortterm);
+		$items = $list->filter('ID', $ids)->sort($sortterm);
 
 		// Ensure that each provided ID corresponded to an actual object.
 		if(count($items) != count($ids)) {


### PR DESCRIPTION
`ArrayList` doesn't have a `byIDs` method so sorting items in an `ArrayList` breaks. This is a more forgiving way of filtering by ID.

Please see https://github.com/silverstripe/silverstripe-framework/pull/3828 - it should be in 3.2.