### PR TITLE
GridFieldOrderableRows: Prefix sort field with table name when sorting

### DIFF
--- a/code/GridFieldOrderableRows.php
+++ b/code/GridFieldOrderableRows.php
@@ -190,7 +190,7 @@ class GridFieldOrderableRows extends RequestHandler implements
 					$sortterm = $this->extraSortFields.', ';
 				}
 			}
-			$sortterm .= $this->getSortField();
+			$sortterm .= $this->getSortTable($list).'.'.$this->getSortField();
 			return $list->sort($sortterm);
 		} else {
 			return $list;
@@ -226,7 +226,7 @@ class GridFieldOrderableRows extends RequestHandler implements
 				$sortterm = $this->extraSortFields.', ';
 			}
 		}
-		$sortterm .= $field;
+		$sortterm .= $this->getSortTable($list).'.'.$field;
 		$items = $list->filter('ID', $ids)->sort($sortterm);
 
 		// Ensure that each provided ID corresponded to an actual object.


### PR DESCRIPTION
Prevents ambiguities when the GridField's underlying DataList uses a query
that joins multiple tables having a sort field.