### PR TITLE
Add support for setting a default value for GridFieldAddNewMultiClasss

### DIFF
--- a/code/GridFieldAddNewMultiClass.php
+++ b/code/GridFieldAddNewMultiClass.php
@@ -19,6 +19,8 @@ class GridFieldAddNewMultiClass implements GridField_HTMLProvider, GridField_URL
 	private $title;
 
 	private $classes;
+	
+	private $defaultClass;
 
 	/**
 	 * @var String
@@ -112,9 +114,21 @@ class GridFieldAddNewMultiClass implements GridField_HTMLProvider, GridField_URL
 	 * @param array $classes a set of class names, optionally mapped to titles
 	 * @return GridFieldAddNewMultiClass $this
 	 */
-	public function setClasses(array $classes) {
+	public function setClasses(array $classes, $default = null) {
 		$this->classes = $classes;
+		if($default) $this->defaultClass = $default;
 		return $this;
+	}
+
+	/**
+	 * Sets the default class that is selected automatically.
+	 *
+	 * @param string $default the class name to use as default
+	 * @return GridFieldAddNewMultiClass $this
+	 */
+	public function setDefaultClass($default) {
+		$this->defaultClass = $default;
+		return $this;	
 	}
 
 	/**
@@ -157,7 +171,7 @@ class GridFieldAddNewMultiClass implements GridField_HTMLProvider, GridField_URL
 
 		GridFieldExtensions::include_requirements();
 
-		$field = new DropdownField(sprintf('%s[ClassName]', __CLASS__), '', $classes);
+		$field = new DropdownField(sprintf('%s[ClassName]', __CLASS__), '', $classes, $this->defaultClass);
 		if (Config::inst()->get('GridFieldAddNewMultiClass', 'showEmptyString')) {
 			$field->setEmptyString(_t('GridFieldExtensions.SELECTTYPETOCREATE', '(Select type to create)'));
 		}


### PR DESCRIPTION
I've added support for setting the default class to be set in the dropdown when using GridFieldAddNewMultiClasss.

My particular use case is I can have one or more subclasses that are able to be added. When there is only _one_ it's useful to be able to set it to be selected in the dropdown by default. There are probably other use cases where it would be useful to set a default value.