### PR TITLE
Add extension hook after re-ordering items

### DIFF
--- a/code/GridFieldOrderableRows.php
+++ b/code/GridFieldOrderableRows.php
@@ -45,6 +45,7 @@ class GridFieldOrderableRows extends RequestHandler implements
 	 * @param string $sortField
 	 */
 	public function __construct($sortField = 'Sort') {
+		parent::__construct();
 		$this->sortField = $sortField;
 	}
 
@@ -351,6 +352,8 @@ class GridFieldOrderableRows extends RequestHandler implements
 				));
 			}
 		}
+
+		$this->extend('onAfterReorderItems', $list);
 	}
 
 	protected function populateSortValues(DataList $list) {


### PR DESCRIPTION
This is useful for things like cache invalidation, as the re-ordering uses `DB::query()` instead of the ORM so there’s no other way to hook into it.

Adding `parent::__construct()` is necessary - without that, extensions aren’t ever registered.