### PR TITLE
Fixed bug where abstract classes aren't ignored with GridFieldAddNewMultiClass

### DIFF
--- a/code/GridFieldAddNewMultiClass.php
+++ b/code/GridFieldAddNewMultiClass.php
@@ -95,7 +95,12 @@ class GridFieldAddNewMultiClass implements GridField_HTMLProvider, GridField_URL
 		foreach($classes as $class => $title) {
 			if(!is_string($class)) {
 				$class = $title;
+				if (($reflection = new ReflectionClass($class)) && $reflection->isAbstract()) {
+					continue;
+				}
 				$title = singleton($class)->i18n_singular_name();
+			} else if (($reflection = new ReflectionClass($class)) && $reflection->isAbstract()) {
+				continue;
 			}
 
 			if(!singleton($class)->canCreate()) {


### PR DESCRIPTION
Fixed bug where abstract classes aren't ignored with GridFieldAddNewMultiClass