### PR TITLE
Updated GridFieldEditableColumns to have nicer defaults, so you can just add it in and it'll "just work" with your 'summary_fields' data.

### DIFF
--- a/code/GridFieldEditableColumns.php
+++ b/code/GridFieldEditableColumns.php
@@ -29,12 +29,37 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
 		}
 
 		$fields = $this->getForm($grid, $record)->Fields();
-		$value  = $grid->getDataFieldValue($record, $col);
-		$rel = (strpos($col,'.') === false); // field references a relation value
-		$field = ($rel) ? clone $fields->fieldByName($col) : new ReadonlyField($col);
 
-		if(!$field) {
-			throw new Exception("Could not find the field '$col'");
+		if (!$this->displayFields)
+		{
+			// If setDisplayFields() not used, utilize $summary_fields
+			// in a way similar to base class
+			$colRelation = explode('.', $col);
+			$value = $grid->getDataFieldValue($record, $colRelation[0]);
+			$field = $fields->fieldByName($colRelation[0]);
+			if (!$field || $field->isReadonly() || $field->isDisabled()) {
+				return parent::getColumnContent($grid, $record, $col);
+			}
+
+			// Ensure this field is available to edit on the record
+			// (ie. Maybe its readonly due to certain circumstances, or removed and not editable)
+			$cmsFields = $record->getCMSFields();
+			$cmsField = $cmsFields->dataFieldByName($colRelation[0]);
+			if (!$cmsField || $cmsField->isReadonly() || $cmsField->isDisabled()) 
+			{
+				return parent::getColumnContent($grid, $record, $col);
+			}
+			$field = clone $field;
+		}
+		else
+		{
+			$value  = $grid->getDataFieldValue($record, $col);
+			$rel = (strpos($col,'.') === false); // field references a relation value
+			$field = ($rel) ? clone $fields->fieldByName($col) : new ReadonlyField($col);
+
+			if(!$field) {
+				throw new Exception("Could not find the field '$col'");
+			}
 		}
 
 		if(array_key_exists($col, $this->fieldCasting)) {
@@ -163,7 +188,24 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
 			}
 
 			if(!$field) {
-				if($class && $obj = singleton($class)->dbObject($col)) {
+				if (!$this->displayFields)
+				{
+					// If setDisplayFields() not used, utilize $summary_fields
+					// in a way similar to base class
+					//
+					// Allows use of 'MyBool.Nice' and 'MyHTML.NoHTML' so that
+					// GridFields not using inline editing still look good or
+					// revert to looking good in cases where the field isn't 
+					// available or is readonly
+					//
+					$colRelation = explode('.', $col);
+					if($class && $obj = singleton($class)->dbObject($colRelation[0])) {
+						$field = $obj->scaffoldFormField();
+					} else {
+						$field = new ReadonlyField($colRelation[0]);
+					}
+				}
+				else if($class && $obj = singleton($class)->dbObject($col)) {
 					$field = $obj->scaffoldFormField();
 				} else {
 					$field = new ReadonlyField($col);


### PR DESCRIPTION
I wanted it to work with my DataObject's summary_fields with no further configuration and I also wanted it to check if the field exists on the record by calling getCMSFields() so that Readonly or removed fields aren't inlined.

Use Case:

class MyDataObject extends DataObject {
        private static $db = array(
		'IsHidden' => 'Boolean',
		'Sort' => 'Int',
	);
	private static $has_one = array(
		'Image' => 'Image',
	);
	private static $summary_fields = array(
		'Image.CMSThumbnail' => 'Thumbnail',
		'Image.Title' => 'Title',
		'IsHidden.Nice' => 'Is Hidden',
	);
}

