### PR TITLE
FIX clickable editable rows

### DIFF
--- a/code/GridFieldEditableColumns.php
+++ b/code/GridFieldEditableColumns.php
@@ -218,6 +218,9 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
 				));
 			}
 
+			// Add CSS class for interactive fields
+			if (!($field->isReadOnly() || $field instanceof LiteralField)) $field->addExtraClass('editable-column-field');
+
 			$fields->push($field);
 		}
 

--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -165,9 +165,12 @@
 		 * GridFieldEditableColumns
 		 */
 
-		$('.ss-gridfield.ss-gridfield-editable .ss-gridfield-item').entwine({
-			onclick: function() {
-				// Stop the default click action when fields are clicked on.
+		$('.ss-gridfield.ss-gridfield-editable .ss-gridfield-item td').entwine({
+			onclick: function(e) {
+				// Prevent the default row click action when clicking a cell that contains a field
+				if (this.find('.editable-column-field').length) {
+					e.stopPropagation();
+				}
 			}
 		});
 


### PR DESCRIPTION
Intention here was apparently to stop the editing form loading when you click form controls added with GridFieldEditableColumns, but it was more aggressive than it needed to be. Now only prevents form load when you click form controls, clicking a regular cell will load the edit form as per standard gridfield behaviour (fixes #135)