### PR TITLE
Added the margin-bottom: 12px; to inline button

### DIFF
--- a/css/GridFieldExtensions.css
+++ b/css/GridFieldExtensions.css
@@ -100,6 +100,10 @@
 	max-width: none !important;
 }
 
+.ss-gridfield-add-new-inline {
+	margin-bottom: 12px;
+}
+
 .ss-gridfield-add-new-inline span.readonly {
 	color: #FFF !important;
 }


### PR DESCRIPTION
Added the margin-bottom: 12px; that's usually applied the '.action' class. Unfortunately putting that class on the button breaks the inline functionality so I opted to just put identical styling into the extension itself.