### PR TITLE
feat(EditableColumns): Added the ability to paste a newline-seperated list of items into an inline TextField, which would automatically populate into multiple rows.

### DIFF
--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -90,6 +90,61 @@
 					if(success) success.apply(grid, arguments);
 				});
 			},
+			onpaste: function(e) {
+				// The following was used as a basis for clipboard data access:
+				// http://stackoverflow.com/questions/2176861/javascript-get-clipboard-data-on-paste-event-cross-browser
+				var clipboardData = typeof e.originalEvent.clipboardData !== "undefined" ? e.originalEvent.clipboardData : null;
+				if (clipboardData) {
+					// Get current input wrapper div class (ie. 'col-Title')
+					var input = $(e.target);
+					var inputType = input.attr('type');
+					if (inputType === 'text' || inputType === 'email')
+					{
+						var lastInput = this.find(".ss-gridfield-inline-new:last").find("input");
+						if (input.attr('type') === 'text' && input.is(lastInput) && input.val() === '')
+						{
+							var inputWrapperDivClass = input.parent().attr('class');
+							// Split clipboard data into lines
+							var lines = clipboardData.getData("text/plain").match(/[^\r\n]+/g);
+							var linesLength = lines.length;
+							// If there are multiple newlines detected, split the data into new rows automatically
+							if (linesLength > 1)
+							{
+								var elementsChanged = [];
+								for (var i = 1; i < linesLength; ++i)
+								{
+									this.trigger("addnewinline");
+									var row = this.find(".ss-gridfield-inline-new:last");
+									var rowInput = row.find("."+inputWrapperDivClass).find("input");
+									rowInput.val(lines[i]);
+									elementsChanged.push(rowInput);
+								}
+								// Store the rows added via this method so they can be undo'd.
+								input.data('pasteManipulatedElements', elementsChanged);
+								// To set the current row to not just be all the clipboard data, must wait a frame
+								setTimeout(function() {
+									input.val(lines[0]);
+								}, 0);
+							}
+						}
+					}
+				}
+			},
+			onkeyup: function(e) {
+				if (e.keyCode == 90 && e.ctrlKey) 
+				{
+					var target = $(e.target);
+					var elementsChanged = target.data("pasteManipulatedElements");
+					if (typeof elementsChanged !== "undefined" && elementsChanged && elementsChanged.length)
+					{
+						for (var i = 0; i < elementsChanged.length; ++i)
+						{
+							elementsChanged[i].closest('tr').remove();
+						}
+						target.data("pasteManipulatedElements", []);
+					}
+				}
+			},
 			onaddnewinline: function(e) {
                 if(e.target != this[0]) {
                     return;


### PR DESCRIPTION
When populating lots of categories/tags provided by a client, you just want to be able to copy-paste the list straight into an inline gridfield setup.

My solution was that if you're on the last inline gridfield row, it's a 'text' type input field, the field is empty and you copy paste a heap of newline-separated text, it will automatically populate all the rows for you.

In the case that the user does not want this behaviour, I've added a CTRL-Z option which undoes this behavior.

ie.
- Pizzazzeria
- Wine
- Bakery
- Subway

If you copy paste the above items into an inline gridfield now, it will automatically separate those items into rows for you.

**Tested and working on Silverstripe 3.3.1 with: **
Chrome 49.0.2623.112 m
Firefox 45.0.1
Microsoft Edge 25.10586.0.0