### PR TITLE
style(EditableColumns/DropdownField): Styled the <select> tag to look like the other input fields.

### DIFF
--- a/css/GridFieldExtensions.css
+++ b/css/GridFieldExtensions.css
@@ -100,6 +100,16 @@
 	max-width: none !important;
 }
 
+.ss-gridfield-editable select.dropdown {
+	border: 1px solid #b3b3b3;
+	padding: 7px 7px;
+	padding-left: 4px;
+	line-height: 16px;
+	-moz-border-radius: 4px;
+	-webkit-border-radius: 4px;
+	border-radius: 4px;
+}
+
 .ss-gridfield-add-new-inline {
 	margin-bottom: 12px;
 }

--- a/css/GridFieldExtensions.css
+++ b/css/GridFieldExtensions.css
@@ -102,6 +102,7 @@
 
 .ss-gridfield-editable select.dropdown {
 	border: 1px solid #b3b3b3;
+	background-color: #fff;
 	padding: 7px 7px;
 	padding-left: 4px;
 	line-height: 16px;


### PR DESCRIPTION
Styled the <select> tag to be more consistent like the other input fields. I experimented with enabling chosen inside the table but the chosen div ends up pushing out the size of the column by a fair bit due to the div not being inline. However making the chosen container div inline breaks the absolute positioning of the dropdown itself.

**Tested aesthetic in:**
Chrome
Firefox
IE8
IE9