### PR TITLE
fix(Documentation): Updated to show third case of needing a custom title and a callback

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -44,6 +44,12 @@ $grid->getConfig()->getComponentByType('GridFieldEditableColumns')->setDisplayFi
 	'SecondField' => array(
 		'title' => 'Custom Title',
 		'field' => 'ReadonlyField'
+	),
+	'ThirdField' => array(
+		'title' => 'Custom Title Two',
+        'callback' => function($record, $column, $grid) {
+            return TextField::create($column);
+        }
 	)
 ));
 ```


### PR DESCRIPTION
Updated to show third case of needing a custom title and a callback.

As per issue here:
[https://github.com/silverstripe-australia/silverstripe-gridfieldextensions/issues/92](url)