### PR TITLE
fix(GridFieldOrderableRows/ArrayList): Fix ->sort on ArrayList

### DIFF
--- a/code/GridFieldOrderableRows.php
+++ b/code/GridFieldOrderableRows.php
@@ -226,7 +226,12 @@ class GridFieldOrderableRows extends RequestHandler implements
 					$sortterm = $this->extraSortFields.', ';
 				}
 			}
-			$sortterm .= '"'.$this->getSortTable($list).'"."'.$this->getSortField().'"';
+			if ($list instanceof ArrayList) {
+				// Fix bug in 3.1.3+ where ArrayList doesn't account for quotes
+				$sortterm .= $this->getSortTable($list).'.'.$this->getSortField();
+			} else {
+				$sortterm .= '"'.$this->getSortTable($list).'"."'.$this->getSortField().'"';
+			}
 			return $list->sort($sortterm);
 		} else {
 			return $list;


### PR DESCRIPTION
Fix ->sort on ArrayList to not use quotes (to work around a bug in framework 3.1+)

**Also PR'd against framework here:**
https://github.com/silverstripe/silverstripe-framework/pull/5726