### PR TITLE
Sort column field label

### DIFF
--- a/code/GridFieldOrderableRows.php
+++ b/code/GridFieldOrderableRows.php
@@ -204,6 +204,10 @@ class GridFieldOrderableRows extends RequestHandler implements
 	}
 
 	public function getColumnMetadata($grid, $col) {
+		if ($fieldLabels = singleton($grid->list->dataClass)->fieldLabels()) {
+			return array('title' => isset($fieldLabels['Reorder']) ? $fieldLabels['Reorder'] : '');
+		}
+
 		return array('title' => '');
 	}
 

--- a/css/GridFieldExtensions.css
+++ b/css/GridFieldExtensions.css
@@ -129,6 +129,7 @@
 
 .ss-gridfield-orderable thead tr th.col-Reorder span {
 	padding: 0 !important;
+	margin-left: 8px;
 }
 
 .ss-gridfield-orderable .col-reorder {


### PR DESCRIPTION
This adds the ability to set the sort column title by setting `$field_labels` of` a `DataObject`.

    private static $field_labels = array(
        'Reorder' => 'Sort'
    );

This allows the user to set a title for the sort column if they like.