### PR TITLE
Bug with reordering sortable grid when some sort IDs are duplicated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,36 @@
-language: php
+# See https://github.com/silverstripe-labs/silverstripe-travis-support for setup details
 
 sudo: false
 
-php: 
+language: php
+
+php:
   - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
 
 env:
-  - DB=MYSQL CORE_RELEASE=3.1
+  - DB=MYSQL CORE_RELEASE=3.2
 
 matrix:
   include:
-    - php: 5.5
+    - php: 5.6
       env: DB=MYSQL CORE_RELEASE=3
     - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.2
-      
+      env: DB=PGSQL CORE_RELEASE=3.1
+    - php: 5.6
+      env: DB=PGSQL CORE_RELEASE=3.3
+    - php: 5.6
+      env: DB=PGSQL CORE_RELEASE=3.4
+  fast_finish: true
+
 before_script:
-  - phpenv rehash
+  - composer self-update || true
   - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
   - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
   - cd ~/builds/ss
+  - composer install
 
 script:
-  - phpunit gridfieldextensions/tests
+  - vendor/bin/phpunit gridfieldextensions/tests

--- a/tests/GridFieldAddNewMultiClassTest.php
+++ b/tests/GridFieldAddNewMultiClassTest.php
@@ -41,7 +41,7 @@ class GridFieldAddNewMultiClassTest extends SapphireTest {
  * @ignore
  */
 
-class GridFieldAddNewMultiClassTest_A {
+class GridFieldAddNewMultiClassTest_A implements TestOnly {
 	public function i18n_singular_name() {
 		$class = get_class($this);
 		return substr($class, strpos($class, '_') + 1);
@@ -52,7 +52,7 @@ class GridFieldAddNewMultiClassTest_A {
 	}
 }
 
-class GridFieldAddNewMultiClassTest_B extends GridFieldAddNewMultiClassTest_A {}
-class GridFieldAddNewMultiClassTest_C extends GridFieldAddNewMultiClassTest_A {}
+class GridFieldAddNewMultiClassTest_B extends GridFieldAddNewMultiClassTest_A implements TestOnly {}
+class GridFieldAddNewMultiClassTest_C extends GridFieldAddNewMultiClassTest_A implements TestOnly {}
 
 /**#@-*/

--- a/tests/GridFieldOrderableRowsTest.php
+++ b/tests/GridFieldOrderableRowsTest.php
@@ -6,11 +6,43 @@ class GridFieldOrderableRowsTest extends SapphireTest {
 
 	protected $usesDatabase = true;
 
+	protected static $fixture_file = 'GridFieldOrderableRowsTest.yml';
+
 	protected $extraDataObjects = array(
 		'GridFieldOrderableRowsTest_Parent',
 		'GridFieldOrderableRowsTest_Ordered',
 		'GridFieldOrderableRowsTest_Subclass',
 	);
+
+	public function testReorderItems() {
+		$orderable = new GridFieldOrderableRows('ManyManySort');
+		$reflection = new ReflectionMethod($orderable, 'executeReorder');
+		$reflection->setAccessible(true);
+
+		$parent = $this->objFromFixture('GridFieldOrderableRowsTest_Parent', 'parent');
+
+		$config = new GridFieldConfig_RelationEditor();
+		$config->addComponent($orderable);
+
+		$grid = new GridField(
+			'MyManyMany',
+			'My Many Many',
+			$parent->MyManyMany()->sort('ManyManySort'),
+			$config
+		);
+
+		$originalOrder = $parent->MyManyMany()->sort('ManyManySort')->column('ID');
+		$desiredOrder = array_reverse($originalOrder);
+
+		$this->assertNotEquals($originalOrder, $desiredOrder);
+
+		$reflection->invoke($orderable, $grid, $desiredOrder);
+
+		$newOrder = $parent->MyManyMany()->sort('ManyManySort')->column('ID');
+
+		$this->assertEquals($desiredOrder, $newOrder);
+
+	}
 
 	/**
 	 * @covers GridFieldOrderableRows::getSortTable

--- a/tests/GridFieldOrderableRowsTest.php
+++ b/tests/GridFieldOrderableRowsTest.php
@@ -6,6 +6,12 @@ class GridFieldOrderableRowsTest extends SapphireTest {
 
 	protected $usesDatabase = true;
 
+	protected $extraDataObjects = array(
+		'GridFieldOrderableRowsTest_Parent',
+		'GridFieldOrderableRowsTest_Ordered',
+		'GridFieldOrderableRowsTest_Subclass',
+	);
+
 	/**
 	 * @covers GridFieldOrderableRows::getSortTable
 	 */
@@ -42,7 +48,7 @@ class GridFieldOrderableRowsTest extends SapphireTest {
  * @ignore
  */
 
-class GridFieldOrderableRowsTest_Parent extends DataObject {
+class GridFieldOrderableRowsTest_Parent extends DataObject implements TestOnly {
 
 	private static $has_many = array(
 		'MyHasMany' => 'GridFieldOrderableRowsTest_Ordered',
@@ -59,7 +65,7 @@ class GridFieldOrderableRowsTest_Parent extends DataObject {
 
 }
 
-class GridFieldOrderableRowsTest_Ordered extends DataObject {
+class GridFieldOrderableRowsTest_Ordered extends DataObject implements TestOnly {
 
 	private static $db = array(
 		'Sort' => 'Int'
@@ -69,9 +75,13 @@ class GridFieldOrderableRowsTest_Ordered extends DataObject {
 		'Parent' => 'GridFieldOrderableRowsTest_Parent'
 	);
 
+	private static $belongs_many_many =array(
+		'MyManyMany' => 'GridFieldOrderableRowsTest_Parent',
+	);
+
 }
 
-class GridFieldOrderableRowsTest_Subclass extends GridFieldOrderableRowsTest_Ordered {
+class GridFieldOrderableRowsTest_Subclass extends GridFieldOrderableRowsTest_Ordered implements TestOnly {
 }
 
 /**#@-*/

--- a/tests/GridFieldOrderableRowsTest.yml
+++ b/tests/GridFieldOrderableRowsTest.yml
@@ -1,0 +1,22 @@
+GridFieldOrderableRowsTest_Ordered:
+  item1:
+  item2:
+  item3:
+  item4:
+  item5:
+  item6:
+GridFieldOrderableRowsTest_Parent:
+  parent:
+    MyManyMany:
+      - 0: =>GridFieldOrderableRowsTest_Ordered.item1
+        ManyManySort: 1
+      - 1: =>GridFieldOrderableRowsTest_Ordered.item2
+        ManyManySort: 1
+      - 2: =>GridFieldOrderableRowsTest_Ordered.item3
+        ManyManySort: 2
+      - 3: =>GridFieldOrderableRowsTest_Ordered.item4
+        ManyManySort: 2
+      - 4: =>GridFieldOrderableRowsTest_Ordered.item5
+        ManyManySort: 108
+      - 5: =>GridFieldOrderableRowsTest_Ordered.item6
+        ManyManySort: 108


### PR DESCRIPTION
My database has somehow entered a state where some sort orders are shared amongst different records.

This is causing the reordering to fail. This PR shows a proof in the form of a unit test.

I'm opening this as I believe the fix is fairly straight forward (just set the sort on all items in the list, instead of just the ones that have changes detected) but this may have unintended side-effects that I'm not aware of, so I wanted to open this and ask first.