### PR TITLE
BUG Ensure that unsaved items can be sorted

### DIFF
--- a/code/GridFieldAddNewInlineButton.php
+++ b/code/GridFieldAddNewInlineButton.php
@@ -101,7 +101,14 @@ class GridFieldAddNewInlineButton implements GridField_HTMLProvider, GridField_S
 
 				$content = $field->Field();
 			} else {
-				$content = null;
+				$content = $grid->getColumnContent($record, $column);
+
+				// Convert GridFieldEditableColumns to the template format
+				$content = str_replace(
+					'[GridFieldEditableColumns][0]',
+					'[GridFieldAddNewInlineButton][{%=o.num%}]',
+					$content
+				);
 			}
 
 			$attrs = '';
@@ -129,7 +136,10 @@ class GridFieldAddNewInlineButton implements GridField_HTMLProvider, GridField_S
 		}
 
 		$class    = $grid->getModelClass();
+		/** @var GridFieldEditableColumns $editable */
 		$editable = $grid->getConfig()->getComponentByType('GridFieldEditableColumns');
+		/** @var GridFieldOrderableRows $sortable */
+		$sortable = $grid->getConfig()->getComponentByType('GridFieldOrderableRows');
 		$form     = $editable->getForm($grid, $record);
 
 		if(!singleton($class)->canCreate()) {
@@ -142,6 +152,12 @@ class GridFieldAddNewInlineButton implements GridField_HTMLProvider, GridField_S
 
 			$form->loadDataFrom($fields, Form::MERGE_CLEAR_MISSING);
 			$form->saveInto($item);
+
+			// Check if we are also sorting these records
+			if ($sortable) {
+				$sortField = $sortable->getSortField();
+				$item->setField($sortField, $fields[$sortField]);
+			}
 
 			if($list instanceof ManyManyList) {
 				$extra = array_intersect_key($form->getData(), (array) $list->getExtraFields());

--- a/code/GridFieldEditableColumns.php
+++ b/code/GridFieldEditableColumns.php
@@ -45,7 +45,7 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
 			// (ie. Maybe its readonly due to certain circumstances, or removed and not editable)
 			$cmsFields = $record->getCMSFields();
 			$cmsField = $cmsFields->dataFieldByName($colRelation[0]);
-			if (!$cmsField || $cmsField->isReadonly() || $cmsField->isDisabled()) 
+			if (!$cmsField || $cmsField->isReadonly() || $cmsField->isDisabled())
 			{
 				return parent::getColumnContent($grid, $record, $col);
 			}
@@ -70,9 +70,9 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
 
 		$field->setName($this->getFieldName($field->getName(), $grid, $record));
 		$field->setValue($value);
-        
+
         if ($field instanceof HtmlEditorField) {
-            return $field->FieldHolder(); 
+            return $field->FieldHolder();
         }
 
 		return $field->forTemplate();
@@ -91,6 +91,9 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
 			return;
 		}
 
+		/** @var GridFieldOrderableRows $sortable */
+		$sortable = $grid->getConfig()->getComponentByType('GridFieldOrderableRows');
+
 		$form = $this->getForm($grid, $record);
 
 		foreach($value[__CLASS__] as $id => $fields) {
@@ -108,6 +111,12 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
 
 			$form->loadDataFrom($fields, Form::MERGE_CLEAR_MISSING);
 			$form->saveInto($item);
+
+			// Check if we are also sorting these records
+			if ($sortable) {
+				$sortField = $sortable->getSortField();
+				$item->setField($sortField, $fields[$sortField]);
+			}
 
 			if($list instanceof ManyManyList) {
 				$extra = array_intersect_key($form->getData(), (array) $list->getExtraFields());
@@ -199,7 +208,7 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
 					//
 					// Allows use of 'MyBool.Nice' and 'MyHTML.NoHTML' so that
 					// GridFields not using inline editing still look good or
-					// revert to looking good in cases where the field isn't 
+					// revert to looking good in cases where the field isn't
 					// available or is readonly
 					//
 					$colRelation = explode('.', $col);

--- a/templates/GridFieldAddNewInlineRow.ss
+++ b/templates/GridFieldAddNewInlineRow.ss
@@ -1,5 +1,5 @@
 <script type="text/x-tmpl" class="ss-gridfield-add-inline-template">
-	<tr class="ss-gridfield-inline-new">
+	<tr class="ss-gridfield-item ss-gridfield-inline-new">
 		<% loop $Me %>
 			<% if $IsActions %>
 				<td$Attributes>

--- a/templates/GridFieldOrderableRowsDragHandle.ss
+++ b/templates/GridFieldOrderableRowsDragHandle.ss
@@ -1,1 +1,2 @@
 <span class="handle"><span class="icon"></span></span>
+$SortField

--- a/tests/GridFieldOrderableRowsTest.php
+++ b/tests/GridFieldOrderableRowsTest.php
@@ -32,13 +32,18 @@ class GridFieldOrderableRowsTest extends SapphireTest {
 		);
 
 		$originalOrder = $parent->MyManyMany()->sort('ManyManySort')->column('ID');
-		$desiredOrder = array_reverse($originalOrder);
+		$desiredOrder = array();
+
+		// Make order non-contiguous, and 1-based
+		foreach(array_reverse($originalOrder) as $index => $id) {
+			$desiredOrder[$index * 2 + 1] = $id;
+		}
 
 		$this->assertNotEquals($originalOrder, $desiredOrder);
 
 		$reflection->invoke($orderable, $grid, $desiredOrder);
 
-		$newOrder = $parent->MyManyMany()->sort('ManyManySort')->column('ID');
+		$newOrder = $parent->MyManyMany()->sort('ManyManySort')->map('ManyManySort', 'ID')->toArray();
 
 		$this->assertEquals($desiredOrder, $newOrder);
 


### PR DESCRIPTION
Fixes #159 (as a side effect)

Prior to this fix, any items created via GridFieldAddNewInlineButton would be unsortable. Now the template will include a sort grabber.

In order to ensure that the sort order is respected properly, the order is set via a hidden field, and is dynamically calculated on the fly with javascript, so that front end drag-dropping updates the record values.

A bit of work was done to ensure that the following components worked together:
- GridFieldEditableColumns
- GridFieldAddNewInlineButton
- GridFieldOrderableRows


Although there is a reference to GridFieldEditableColumns within GridFieldAddNewInlineButton, it's not actually necessary for it to be included in the same form for GridFieldAddNewInlineButton to work.

Likewise, GridFieldAddNewInlineButton will pick up the hidden field from GridFieldOrderableRows, and will use string replacement to rename the hidden field from '[GridFieldEditableColumns][0]' to '[GridFieldAddNewInlineButton][{%=o.num%}]' for use in the template.

Within GridFieldOrderableRows I've changed the behaviour so that the old 'order' posted property is no longer needed; Only the new hidden field will be necessary to post back. This does mean that in some cases, the SAME sort value may be saved twice by multiple components, but it is always consistent, and thus safe.

 
 