### PR TITLE
Added extra protection in case onadd update has ui == undefined

### DIFF
--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -309,7 +309,7 @@
 				var update = function(event, ui) {
 					// If the item being dragged is unsaved, don't do anything
 					var postback = true;
-					if (ui.item.hasClass('ss-gridfield-inline-new')) {
+					if ((ui != undefined) && ui.item.hasClass('ss-gridfield-inline-new')) {
 						postback = false;
 					}
 


### PR DESCRIPTION
Fix for javascriptscript errors while using GridFieldOrderableRows with module https://github.com/micschk/silverstripe-groupable-gridfield