### PR TITLE
fix(GridFieldAddNewMultiClass): Fix bug where class doesn't exist.

### DIFF
--- a/code/GridFieldAddNewMultiClass.php
+++ b/code/GridFieldAddNewMultiClass.php
@@ -96,12 +96,13 @@ class GridFieldAddNewMultiClass implements GridField_HTMLProvider, GridField_URL
 		foreach($classes as $class => $title) {
 			if(!is_string($class)) {
 				$class = $title;
-				$is_abstract = (($reflection = new ReflectionClass($class)) && $reflection->isAbstract());
-				if (!$is_abstract) {
-					$title = singleton($class)->i18n_singular_name();
-				}
-			} else {
-				$is_abstract = (($reflection = new ReflectionClass($class)) && $reflection->isAbstract());
+			}
+			if (!class_exists($class)) {
+				continue;
+			}
+			$is_abstract = (($reflection = new ReflectionClass($class)) && $reflection->isAbstract());
+			if (!$is_abstract && $class === $title) {
+				$title = singleton($class)->i18n_singular_name();
 			}
 
 			if ($ancestor_to_hide = Config::inst()->get($class, 'hide_ancestor', Config::FIRST_SET)) {


### PR DESCRIPTION
Fix bug where class doesn't exist.

(ie. ClassInfo says the class exists, but PHP itself doesn't, since ClassInfo is based on parsed tokens)