### PR TITLE
FIX: Prevent duplicate HTML IDs when adding new records inline

### DIFF
--- a/code/GridFieldAddNewInlineButton.php
+++ b/code/GridFieldAddNewInlineButton.php
@@ -100,6 +100,13 @@ class GridFieldAddNewInlineButton implements GridField_HTMLProvider, GridField_S
 				));
 
 				$content = $field->Field();
+
+				// Convert HTML IDs built by FormTemplateHelper to the template format
+				$content = str_replace(
+					'GridFieldAddNewInlineButton_o.num_',
+					'GridFieldAddNewInlineButton_{%=o.num%}_',
+					$content
+				);
 			} else {
 				$content = $grid->getColumnContent($record, $column);
 


### PR DESCRIPTION
The JS template functionality replaces the `{%=o.num%}` placeholder with a number that increments for each new row added. This works for the `name` attributes, but the placeholders in `id` attributes get converted to `_o.num_` by `FormTemplateHandler` in newer versions of SilverStripe.

This converts them back to the correct placeholder format, which is perfectly valid in HTML5 (https://www.w3.org/TR/html5/dom.html#the-id-attribute)