### PR TITLE
Initialising button before attempting to enable or disable it

### DIFF
--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -239,9 +239,9 @@
 				var btn = this.parents(".ss-gridfield-add-new-multi-class").find(".ss-ui-button");
 
 				if(this.val() && this.val().length) {
-					btn.button("enable");
+					btn.button().button("enable");
 				} else {
-					btn.button("disable");
+					btn.button().button("disable");
 				}
 			}
 		});

--- a/src/GridFieldAddNewInlineButton.php
+++ b/src/GridFieldAddNewInlineButton.php
@@ -13,6 +13,7 @@ use SilverStripe\ORM\DataObjectInterface;
 use SilverStripe\ORM\ManyManyList;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\Requirements;
+use Exception;
 
 /**
  * Builds on the {@link GridFieldEditableColumns} component to allow creating new records.

--- a/src/GridFieldAddNewMultiClass.php
+++ b/src/GridFieldAddNewMultiClass.php
@@ -41,7 +41,7 @@ class GridFieldAddNewMultiClass implements GridField_HTMLProvider, GridField_URL
     /**
      * @var string
      */
-    protected $itemRequestClass = 'SilverStripe\\Forms\\GridField\\GridFieldAddNewMultiClassHandler';
+    protected $itemRequestClass = 'SilverStripe\\GridFieldExtensions\\GridFieldAddNewMultiClassHandler';
 
     /**
      * @param string $fragment the fragment to render the button in

--- a/src/GridFieldAddNewMultiClass.php
+++ b/src/GridFieldAddNewMultiClass.php
@@ -13,6 +13,7 @@ use SilverStripe\Forms\GridField\GridField_HTMLProvider;
 use SilverStripe\Forms\GridField\GridField_URLHandler;
 use SilverStripe\View\ArrayData;
 use ReflectionClass;
+use Exception;
 
 /**
  * A component which lets the user select from a list of classes to create a new record form.

--- a/src/GridFieldEditableColumns.php
+++ b/src/GridFieldEditableColumns.php
@@ -17,6 +17,7 @@ use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\ORM\DataObjectInterface;
 use SilverStripe\ORM\ManyManyList;
+use Exception;
 
 /**
  * Allows inline editing of grid field records without having to load a separate

--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -20,6 +20,7 @@ use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\SS_Map;
 use SilverStripe\View\ViewableData;
+use Exception;
 
 /**
  * Allows grid field rows to be re-ordered via drag and drop. Both normal data

--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -20,6 +20,7 @@ use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\SS_Map;
 use SilverStripe\View\ViewableData;
+use League\Flysystem\Exception;
 
 /**
  * Allows grid field rows to be re-ordered via drag and drop. Both normal data

--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -20,7 +20,6 @@ use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\SS_Map;
 use SilverStripe\View\ViewableData;
-use League\Flysystem\Exception;
 
 /**
  * Allows grid field rows to be re-ordered via drag and drop. Both normal data


### PR DESCRIPTION
When trying to enable or disable buttons before running an initialisation for the button, an error will be thrown. I have just called the button function prior to enabling or disabling the button to combat this. I have also updated a class reference in GridFieldAddNewMultiClass.php as this was pointing to a non-existent class. I have added a use statement for Exception also.