### PR TITLE
Fix for Exception namespace & CSS image move

### DIFF
--- a/css/GridFieldExtensions.css
+++ b/css/GridFieldExtensions.css
@@ -154,7 +154,7 @@
 	width: 5px;
 	height: 11px;
 	margin: -5px 0 0 -2px;
-	background-image: url('../../framework/thirdparty/jquery-ui-themes/smoothness/images/ui-icons_222222_256x240.png');
+	background-image: url('../../framework/admin/thirdparty/jquery-ui-themes/smoothness/images/ui-icons_222222_256x240.png');
 	background-position: -5px -227px;
 }
 

--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -239,9 +239,9 @@
 				var btn = this.parents(".ss-gridfield-add-new-multi-class").find(".ss-ui-button");
 
 				if(this.val() && this.val().length) {
-					btn.button("enable");
+					btn.button().button("enable");
 				} else {
-					btn.button("disable");
+					btn.button().button("disable");
 				}
 			}
 		});

--- a/src/GridFieldAddNewMultiClass.php
+++ b/src/GridFieldAddNewMultiClass.php
@@ -41,7 +41,7 @@ class GridFieldAddNewMultiClass implements GridField_HTMLProvider, GridField_URL
     /**
      * @var string
      */
-    protected $itemRequestClass = 'SilverStripe\\Forms\\GridField\\GridFieldAddNewMultiClassHandler';
+    protected $itemRequestClass = 'SilverStripe\\GridFieldExtensions\\GridFieldAddNewMultiClassHandler';
 
     /**
      * @param string $fragment the fragment to render the button in

--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -196,7 +196,7 @@ class GridFieldOrderableRows extends RequestHandler implements
             }
         }
 
-        throw new Exception("Couldn't find the sort field '$field'");
+        throw new \Exception("Couldn't find the sort field '$field'");
     }
 
     public function getURLHandlers($grid)


### PR DESCRIPTION
Missing '\\' before Exception
Icon has moved in Framework