### PR TITLE
Fix SearchForm throwing a 404 on search

### DIFF
--- a/src/GridFieldAddExistingSearchHandler.php
+++ b/src/GridFieldAddExistingSearchHandler.php
@@ -75,7 +75,7 @@ class GridFieldAddExistingSearchHandler extends RequestHandler
     {
         $form = new Form(
             $this,
-            'SilverStripe\\CMS\\Search\\SearchForm',
+            'SearchForm',
             $this->context->getFields(),
             new FieldList(
                 FormAction::create('doSearch', _t('GridFieldExtensions.SEARCH', 'Search'))


### PR DESCRIPTION
The GridFieldAddExistingSearchHandler search has been converted to namespaces however this causes the FormAction to be incorrect and when performing a search, currently throws an error. The form name does not need to be namespaced.