### PR TITLE
Support table namespace separator introduced in SilverStripe 4 alpha 6

### DIFF
--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -13,6 +13,7 @@ use SilverStripe\Forms\GridField\GridField_SaveHandler;
 use SilverStripe\Forms\GridField\GridField_URLHandler;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObjectInterface;
@@ -193,7 +194,7 @@ class GridFieldOrderableRows extends RequestHandler implements
 
         foreach ($classes as $class) {
             if (singleton($class)->hasDataBaseField($field)) {
-                return $class;
+                return DataObject::getSchema()->tableName($class);
             }
         }
 


### PR DESCRIPTION
silverstripe/silverstripe-framework#6728 switched the default table namespace separator to `_`, rather than matching that of the PHP class. This means that just using the class name as table name no longer works.

A lookup of the tableName from Framework fixes this and also adds support for custom table names that have been set in private statics or yaml.